### PR TITLE
automatically link/unlink the agent on machine start/stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ansible-role-nessus-agent
 =========
 
-Ansible role for installing and configuring Nessus Agent
+Ansible role for installing and configuring Nessus Agent. It will automatically [link](https://docs.tenable.com/nessus/7_0/Content/InstallNessusAgentLinux.htm) the Agent when the machine is started, and unlink it when the machine is stopped.
 
 https://galaxy.ansible.com/singleplatform-eng/nessus-agent/
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,11 @@ nessus_agent_package: 'NessusAgent'
 
 nessus_agent_host: cloud.tenable.com
 nessus_agent_port: 443
+
+nessus_cli_path: /opt/nessus_agent/sbin/nessuscli
+nessus_link_command: >
+  {{ nessus_cli_path }} agent link \
+    --key={{nessus_agent_key}} \
+    --host={{nessus_agent_host}} \
+    --port={{nessus_agent_port}} \
+    --groups="{{nessus_agent_group}}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,6 @@
 ---
-
 - name: restart nessusagent
   service: name=nessusagent state=restarted
+
+- name: restart nessus_link
+  systemd: name=nessus_link state=restarted daemon_reload=true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,22 +8,18 @@
   apt: deb={{nessus_agent_package}}
   when: "'.deb' in nessus_agent_package"
 
-- name: Check agent link status
-  command: /opt/nessus_agent/sbin/nessuscli agent status
-  become: yes
-  ignore_errors: yes
-  register: nessus_link
+- name: Create Nessus linking service
+  template: src=nessus_link.service dest=/etc/systemd/system/nessus_link.service
+  notify:
+    - restart nessusagent
+    - restart nessus_link
 
-- name: Configure Nessus Agent
-  command: >
-      /opt/nessus_agent/sbin/nessuscli agent link
-      --key={{nessus_agent_key}}
-      --host={{nessus_agent_host}}
-      --port={{nessus_agent_port}}
-      --groups="{{nessus_agent_group}}"
-  become: yes
-  when: nessus_link|failed
-  notify: restart nessusagent
+- name: Ensure nessus_link is started
+  service: name=nessus_link state=started enabled=yes
 
 - name: Ensure nessusagent is started
   service: name=nessusagent state=started enabled=yes
+
+- name: Check agent link status
+  command: "{{ nessus_cli_path }} agent status"
+  become: yes

--- a/templates/nessus_link.service
+++ b/templates/nessus_link.service
@@ -1,0 +1,13 @@
+# adapted from https://askubuntu.com/a/795406/501568
+
+[Unit]
+Description=Link and unlink Nessus Agent
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart={{ nessus_link_command }}
+ExecStop={{ nessus_cli_path }} agent unlink
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
At @GSA, we were running into the issue of Nessus Agents remaining linked even after their virtual machine was gone. Rather than having Ansible do the linking, this instead uses a systemd service to link and unlink the Agent when the service (and thus the machine) is started or stopped, respectively.

I'm new to Nessus and writing systemd services, so it's very possible there are downsides of this approach I'm not thinking of. Feedback welcome!