### PR TITLE
only report changed when nessus link fails, remove tests as filters deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,8 +16,9 @@
   - name: Check agent link status
     command: /opt/nessus_agent/sbin/nessuscli agent status
     become: yes
-    ignore_errors: yes
     register: nessus_link
+    ignore_errors: yes
+    changed_when: nessus_link.rc != 0
 
   - name: Configure Nessus Agent
     command: >
@@ -27,7 +28,7 @@
         --port={{nessus_agent_port}}
         --groups="{{nessus_agent_group}}"
     become: yes
-    when: nessus_link|failed
+    when: nessus_link is failed
     notify: restart nessusagent
 
   - name: Ensure nessusagent is started


### PR DESCRIPTION
Only reports changed on link task when it fails and resolves deprecation warning.

```
TASK [singleplatform-eng.nessus-agent : Configure Nessus Agent] *****************************************************************************
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|failed` instead use `result is failed`. This feature
will be removed in version 2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```